### PR TITLE
Update 01-error-handling.yaml

### DIFF
--- a/Day-08/01-error-handling.yaml
+++ b/Day-08/01-error-handling.yaml
@@ -1,8 +1,12 @@
 ---
 - hosts: all
   become: true
-
+  
   tasks:
+    - name: Update apt cache    # if you face this error while executing " No package matching 'docker.io' is available " Be Ensure your Ansible playbook includes a task to update the apt cache before attempting to install any packages.
+       ansible.builtin.apt:
+         update_cache: yes  
+       
     - name: Install security updates
       ansible.builtin.apt:
         name: "{{ item }}"


### PR DESCRIPTION
# While executing this playbook i got this error **No package matching 'docker.io' is available**
![Screenshot (750)](https://github.com/iam-veeramalla/ansible-zero-to-hero/assets/89016145/065d39d1-2255-4ac5-a2f3-215558744182)

# For handle this issue 

1. Ensure your Ansible playbook includes a task to update the apt cache before attempting to install any packages.
 ```
 - name: Update apt cache
  apt:
    update_cache: yes
```
2. Here is the full playbook code
```
- hosts: all
  become: true

  tasks:
    - name: Enable universe repository
      ansible.builtin.command: add-apt-repository universe
      register: universe_result
      changed_when: "'universe' in universe_result.stdout"

    - name: Update apt cache
      ansible.builtin.apt:
        update_cache: yes

    - name: Make sure the packages and openssl are up to date
      ansible.builtin.apt:
        name: "{{ item }}"
        state: latest
      loop:
        - openssh-server
        - openssl
      ignore_errors: yes

    - name: Verify if Docker is installed
      ansible.builtin.command: docker --version
      register: output
      ignore_errors: yes

    - name: Install Docker
      ansible.builtin.apt:
        name: docker.io
        state: present
      when: output.failed
```
