### PR TITLE
Update ec2_create.yaml

### DIFF
--- a/Day-07/ec2_create.yaml
+++ b/Day-07/ec2_create.yaml
@@ -9,6 +9,7 @@
       key_name: "abhi-aws-keypair"
       instance_type: t2.micro
       security_group: default
+      vpc_subnet_id: "Add subnet_id" # Add subnet id according to region
       region: ap-south-1
       aws_access_key: "{{ec2_access_key}}"  # From vault as defined
       aws_secret_key: "{{ec2_secret_key}}"  # From vault as defined      


### PR DESCRIPTION
Summary
This pull request updates ec2_create.yaml to include a placeholder for the vpc_subnet_id. Previously, the absence of this parameter was causing EC2 instance creation failures. The added placeholder guides users to insert the appropriate subnet ID based on their AWS region.

Changes Made
Added a comment in ec2_create.yaml to specify where to provide the vpc_subnet_id.
Reason
The update prevents creation issues by clarifying where to enter the vpc_subnet_id, improving setup clarity for new users.

Thank you!

